### PR TITLE
#165427233:exempt src/routes/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "coverage": "react-scripts test -u --env=jsdom --coverage --coveragePathIgnorePatterns=src/index.jsx --coveragePathIgnorePatterns=src/serviceWorker.js",
+    "coverage": "react-scripts test -u --env=jsdom --coverage --coveragePathIgnorePatterns=src/index.jsx --coveragePathIgnorePatterns=src/serviceWorker.js --coveragePathIgnorePatterns=src/routes/index.js",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
#### Description
Currently, the file is letting down the app test coverage.
While there are ways to test, it has proved to be complicated and time-consuming.

#### Notes
Testing this won't be needed because:
1. The whole app is currently being tested, this means its working well.
2. Testing this piece is complicated and may bring errors when executing other features.