### PR TITLE
#165439124: Bug-fix  Axios Throwing Config Errors

### DIFF
--- a/src/axiosConfig.js
+++ b/src/axiosConfig.js
@@ -8,4 +8,14 @@ const axiosConfig = axios.create({
     'content-type': 'application/json',
   },
 });
+
+
+export const axiosConfigAuth = axios.create({
+  baseURL: REACT_APP_BASE_URL,
+  headers: {
+    'content-type': 'application/json',
+    authorization: `Bearer ${localStorage.token}`,
+  },
+});
+
 export default axiosConfig;

--- a/src/store/actions/articleActions.js
+++ b/src/store/actions/articleActions.js
@@ -1,7 +1,7 @@
 import { PERSONAL_ARTICLES_FETCHED, AUTHENTICATION_FAILED } from './actionTypes';
-import axiosConfig from '../../axiosConfig';
+import { axiosConfigAuth } from '../../axiosConfig';
 
-const fetchPersonalArticles = () => dispatch => axiosConfig.request({
+const fetchPersonalArticles = () => dispatch => axiosConfigAuth.request({
   method: 'get',
   url: '/user/articles/',
 })

--- a/src/store/actions/profileActions.js
+++ b/src/store/actions/profileActions.js
@@ -5,9 +5,9 @@ import {
   PROFILE_UPDATE_FAILED,
   AUTHENTICATION_FAILED,
 } from './actionTypes';
-import axiosConfig from '../../axiosConfig';
+import { axiosConfigAuth } from '../../axiosConfig';
 
-export const fetchProfile = () => dispatch => axiosConfig.request({
+export const fetchProfile = () => dispatch => axiosConfigAuth.request({
   method: 'get',
   url: 'user/',
 })
@@ -23,7 +23,7 @@ export const fetchProfile = () => dispatch => axiosConfig.request({
       payload: error.response.data,
     });
   });
-export const updateProfile = updatedProfileInfo => dispatch => axiosConfig.request({
+export const updateProfile = updatedProfileInfo => dispatch => axiosConfigAuth.request({
   method: 'put',
   url: 'user/',
   data: updatedProfileInfo,

--- a/src/tests/actions/articleActions.test.js
+++ b/src/tests/actions/articleActions.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import promiseMiddleware from 'redux-promise-middleware';
-import axiosconfig from '../../axiosConfig';
+import { axiosConfigAuth } from '../../axiosConfig';
 import moxios from 'moxios';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -16,10 +16,10 @@ describe('async actions', () => {
   const middlewares = [promiseMiddleware()];
 
   beforeEach(() => {
-    moxios.install(axiosconfig);
+    moxios.install(axiosConfigAuth);
   });
   afterEach(() => {
-    moxios.uninstall(axiosconfig);
+    moxios.uninstall(axiosConfigAuth);
   });
   it('it dispatches PERSONAL_ARTICLES_FETCHED on fetchPersonalArticles', () => {
     const payload = { profile };

--- a/src/tests/actions/profileActions.test.js
+++ b/src/tests/actions/profileActions.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import promiseMiddleware from 'redux-promise-middleware';
-import axiosconfig from '../../axiosConfig';
+import { axiosConfigAuth } from '../../axiosConfig';
 import moxios from 'moxios';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -16,10 +16,10 @@ describe('async actions', () => {
   const middlewares = [promiseMiddleware()];
 
   beforeEach(() => {
-    moxios.install(axiosconfig);
+    moxios.install(axiosConfigAuth);
   });
   afterEach(() => {
-    moxios.uninstall(axiosconfig);
+    moxios.uninstall(axiosConfigAuth);
   });
   it('it dispatches PROFILE_FETCHED on fetchProfile', () => {
     const payload = { errors };


### PR DESCRIPTION
#### Why is this needed?
Currently, when a request is made to public endpoints, an error is thrown because the main axios instance has authorization header:


#### Step to fix it:
Create a separate config instance for public endpoints: 

#### Changelog:
Use the following axios instance to access endpoints:
1. Public: axiosConfig
2. Private: axiosConfigAuth