### PR TITLE
[#165438637] Login button is not disable when the modal is closed

### DIFF
--- a/src/axiosConfig.js
+++ b/src/axiosConfig.js
@@ -6,7 +6,6 @@ const axiosConfig = axios.create({
   baseURL: REACT_APP_BASE_URL,
   headers: {
     'content-type': 'application/json',
-    authorization: `Bearer ${localStorage.token}`,
   },
 });
 export default axiosConfig;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import { Navbar, Nav } from 'react-bootstrap';
 import { NavLink } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import AuthenticationModal from './AuthenticationModal';
 import store from '../store/store';
 import { LOGIN, REGISTER } from '../store/actions/actionTypes';
 import AlertModal from './AlertModal';
-import { isLoggedIn } from '../utils/tokenValidator';
 
-class Header extends React.Component {
-  state = {
-    LoggedIn: isLoggedIn,
-  };
-
+export class Header extends React.Component {
   dispatchLogin = () => {
     store.dispatch({ type: LOGIN });
   };
@@ -21,7 +18,7 @@ class Header extends React.Component {
   };
 
   render() {
-    const { LoggedIn } = this.state;
+    const { loggedIn } = this.props;
     return (
       <Navbar expand="lg" className="navbar-custom">
         <NavLink exact to="/" className="brand">
@@ -29,7 +26,7 @@ class Header extends React.Component {
         </NavLink>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
-          {LoggedIn ? (
+          {loggedIn ? (
             <Nav className="ml-auto">
               <Nav.Item className="nav-link profile-dropdown">
                 Your Profile
@@ -59,4 +56,10 @@ class Header extends React.Component {
   }
 }
 
-export default Header;
+Header.propTypes = {
+  loggedIn: PropTypes.bool.isRequired,
+};
+
+export const mapStateToProps = state => state.loginUser;
+
+export default connect(mapStateToProps)(Header);

--- a/src/containers/LoginForm.jsx
+++ b/src/containers/LoginForm.jsx
@@ -42,7 +42,7 @@ export class LoginForm extends React.Component {
         formErrors: [],
       });
       const data = { email, password };
-      store.dispatch({ type: IS_LOADING, payload: true });
+      store.dispatch({ type: IS_LOADING, payload: { isLoading: true } });
       LoginUser(data);
     } else {
       this.setState({
@@ -139,7 +139,7 @@ export class LoginForm extends React.Component {
 
 LoginForm.propTypes = {
   loginUser: PropTypes.shape({
-    logged_in: PropTypes.bool,
+    loggedIn: PropTypes.bool,
     errors: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     isLoading: PropTypes.bool,
   }).isRequired,

--- a/src/store/actions/authActions/LoginAction.js
+++ b/src/store/actions/authActions/LoginAction.js
@@ -24,7 +24,7 @@ const loginAction = loginData => dispatch => axiosConfig.request({
     });
     dispatch({
       type: IS_LOADING,
-      payload: false,
+      payload: { isLoading: false },
     });
   })
   .catch((error) => {
@@ -34,7 +34,7 @@ const loginAction = loginData => dispatch => axiosConfig.request({
     });
     dispatch({
       type: IS_LOADING,
-      payload: false,
+      payload: { isLoading: false },
     });
   });
 

--- a/src/store/reducers/LoginReducer.js
+++ b/src/store/reducers/LoginReducer.js
@@ -2,7 +2,7 @@ import { LOGIN_SUCCESS, LOGIN_FAIL, IS_LOADING } from '../actions/actionTypes';
 import { isLoggedIn } from '../../utils/tokenValidator';
 
 const initialState = {
-  logged_in: !!isLoggedIn,
+  loggedIn: !!isLoggedIn,
   errors: '',
   isLoading: false,
 };
@@ -12,19 +12,19 @@ const loginReducer = (state = initialState, action) => {
     case LOGIN_SUCCESS:
       return {
         ...state,
-        logged_in: true,
+        loggedIn: true,
         errors: '',
       };
     case LOGIN_FAIL:
       return {
         ...state,
-        logged_in: false,
+        loggedIn: false,
         errors: action.payload,
       };
     case IS_LOADING:
       return {
         ...state,
-        isLoading: action.payload,
+        isLoading: action.payload.isLoading,
       };
     default:
       return state;

--- a/src/tests/components/Header.test.js
+++ b/src/tests/components/Header.test.js
@@ -1,10 +1,12 @@
 import { shallow, mount } from "enzyme";
-import Header from "../../components/Header";
+import { Header } from "../../components/Header";
 import React from "react";
-import { isLoggedIn } from '././../../utils/tokenValidator';
 
 describe("Header", () => {
-  const component = shallow(<Header />);
+  const props = {
+    loggedIn: false,
+  }
+  const component = shallow(<Header {...props}/>);
   const componentInstance = component.instance();
   const createSpy = toSpy => jest.spyOn(componentInstance, toSpy);
   it("renders one Header", () => {
@@ -24,11 +26,18 @@ describe("Header", () => {
     register.simulate("click");
     expect(dispatchRegister).toHaveBeenCalled();
   });
-  it("shows profile icon dropdown when a user logs in", () => {
+})
 
-    component.setState({ LoggedIn: true})
-    const profileDropdown = component.find(".profile-dropdown");
+describe('Header when a user logs in', () => {
+  it("shows profile icon dropdown when a user logs in", () => {
+    const props = {
+      loggedIn: true
+    }
+    const wrapper = shallow(<Header {...props} />)
+
+    const profileDropdown = wrapper.find(".profile-dropdown");
     expect(profileDropdown.length).toEqual(1);
-    expect(component.find(".login").length).toEqual(0);
+    expect(wrapper.find(".login").length).toEqual(0);
   });
 });
+

--- a/src/tests/components/UserProfile.test.js
+++ b/src/tests/components/UserProfile.test.js
@@ -129,9 +129,7 @@ describe('<UserProfileComponent />', () => {
   it('Should update state on receiving errors in props', () => {
     const wrapper = shallow(<UserProfileComponent {...props} />);
     const wrapperInstance = wrapper.instance();
-    console.log(wrapperInstance.state)
     wrapper.setProps({profileUpdated:true,authenticated:true, error:true, errors: {errors: {username:'not good',profile : {website:['thats not a good one']}}}})
-    console.log(wrapperInstance)
     const { formErrorFields } = wrapperInstance.state;
     expect(formErrorFields).toEqual(["username","profile","website",]);
     });

--- a/src/tests/containers/LoginForm.test.js
+++ b/src/tests/containers/LoginForm.test.js
@@ -162,7 +162,7 @@ describe("mapStateToProps function", () => {
   it("should map the state we pass to the props", () => {
     const state = {
       loginUser: {
-        logged_in: false,
+        loggedIn: false,
         errors: ""
       }
     };

--- a/src/tests/store/reducers/LoginReducer.test.js
+++ b/src/tests/store/reducers/LoginReducer.test.js
@@ -3,7 +3,7 @@ import loginReducer from "../../../store/reducers/LoginReducer";
 
 describe("loginReducer", () => {
   const initialState = {
-    logged_in: false,
+    loggedIn: false,
     errors: ""
   };
   it("should dispatch success action on login success", () => {
@@ -11,7 +11,7 @@ describe("loginReducer", () => {
       type: LOGIN_SUCCESS
     };
     const successState = {
-      logged_in: true,
+      loggedIn: true,
       errors: ""
     };
     expect(loginReducer(initialState, loginSuccess)).toEqual(successState);
@@ -22,11 +22,11 @@ describe("loginReducer", () => {
       payload: "A user with this email and password was not found"
     };
     const failureState = {
-      logged_in: false,
+      loggedIn: false,
       errors: loginFail.payload
     };
     const successState = {
-      logged_in: true,
+      loggedIn: true,
       errors: ""
     };
     expect(loginReducer(initialState, loginFail)).toEqual(failureState);
@@ -38,7 +38,7 @@ describe("loginReducer", () => {
       type: LOGIN_TRIAL
     };
     const defaultState = {
-      logged_in: false,
+      loggedIn: false,
       errors: ""
     };
     expect(loginReducer(initialState, invalidType)).toEqual(defaultState);


### PR DESCRIPTION
### What does this PR
This is a bugfix. When the login modal is closed, the login button keeps loading because the wrong payload is dispatched. This PR fixes that. This PR also makes the header responsive in that whenever a user logs in such that the login and register links are not displayed anymore.

### Description
To reproduce the bug, open the login modal and close it. When you reopen the modal, the login button is disabled. This should not be the case because users should be able to close and reopen the modal always. The header links should also be replaced whenever a user successfully logs in. Later on, we will ad a logout link whenever a user logs in.

### How has this been tested?
- [x] End-to-end tests
- [x] Unit tests

### PT
[165438637](https://www.pivotaltracker.com/story/show/165438637)