### PR TITLE
 #165530654 Verify users' emails

### DIFF
--- a/src/components/AuthenticationModal.jsx
+++ b/src/components/AuthenticationModal.jsx
@@ -7,7 +7,7 @@ import RegisterForm from './RegisterForm';
 import Login from './Login';
 import ShowModal from '../store/actions/changeFormAction';
 import { showErrors } from '../store/actions/registerActions';
-import { IS_LOADING, REDIRECT } from '../store/actions/actionTypes';
+import { IS_LOADING } from '../store/actions/actionTypes';
 import InitiateResetForm from './InitateResetForm';
 import PasswordResetForm from './PasswordResetForm';
 
@@ -18,7 +18,6 @@ export class ConnectedAuthenticationModal extends React.Component {
       dispatch(ShowModal({ modalShow: false }));
       dispatch({ type: IS_LOADING, payload: { isLoading: false } });
       dispatch(showErrors({}));
-      dispatch({ type: REDIRECT, payload: { redirect: false } });
     };
     let CurrentComponent;
     let headerMessage;

--- a/src/components/PasswordResetForm.jsx
+++ b/src/components/PasswordResetForm.jsx
@@ -6,11 +6,7 @@ import ButtonSpinner from './ButtonSpinner';
 import { passwordReset } from '../store/actions/passwordResetActions';
 import validate from '../utils/registerFormValidator';
 import store from '../store/store';
-import { IS_LOADING, REDIRECT } from '../store/actions/actionTypes';
-
-const results = window.location.href.split('/');
-const token = results[results.length - 1];
-store.dispatch({ type: REDIRECT, payload: { redirect: true } });
+import { IS_LOADING } from '../store/actions/actionTypes';
 
 export class ConnectedPasswordResetForm extends Component {
   constructor() {
@@ -28,7 +24,7 @@ export class ConnectedPasswordResetForm extends Component {
 
   handleSubmit = (event) => {
     const { password, confirmPassword } = this.state;
-    const { PasswordReset } = this.props;
+    const { PasswordReset, token } = this.props;
     event.preventDefault();
     const errors = validate('', '', password, confirmPassword);
     if (!errors.password && !errors.confirmPassword) {
@@ -59,7 +55,7 @@ export class ConnectedPasswordResetForm extends Component {
             <Form.Text className="error-text">{errors.password}</Form.Text>
             <Form.Control
               className={errors.password && 'error'}
-              type="text"
+              type="password"
               name="password"
               id="password"
               onChange={this.handleChange}
@@ -70,7 +66,7 @@ export class ConnectedPasswordResetForm extends Component {
             <Form.Text className="error-text">{errors.confirmPassword}</Form.Text>
             <Form.Control
               className={errors.confirmPassword && 'error'}
-              type="text"
+              type="password"
               name="confirmPassword"
               onChange={this.handleChange}
             />
@@ -90,6 +86,7 @@ export class ConnectedPasswordResetForm extends Component {
 ConnectedPasswordResetForm.propTypes = {
   PasswordReset: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  token: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = state => state.resetPasswordState;

--- a/src/components/ResetPassword.jsx
+++ b/src/components/ResetPassword.jsx
@@ -1,26 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import store from '../store/store';
-import { PASSWORD_RESET } from '../store/actions/actionTypes';
+import { PASSWORD_RESET, SET_TOKEN } from '../store/actions/actionTypes';
 
-export class ConnectedResetPassword extends React.Component {
+class ResetPassword extends React.Component {
   componentDidMount() {
     store.dispatch({ type: PASSWORD_RESET });
+    const { match: { params } } = this.props;
+    const { resetToken } = params;
+    store.dispatch({ type: SET_TOKEN, payload: { token: resetToken } });
   }
 
   render() {
-    const { redirect } = this.props;
-    return (<>{redirect && <Redirect to="/" />}</>);
+    return (<Redirect to="/" />);
   }
 }
 
-ConnectedResetPassword.propTypes = {
-  redirect: PropTypes.bool.isRequired,
+ResetPassword.propTypes = {
+  match: PropTypes.shape({}).isRequired,
 };
 
-export const mapStateToProps = state => state.resetPasswordState;
-
-const ResetPassword = connect(mapStateToProps)(ConnectedResetPassword);
 export default ResetPassword;

--- a/src/store/actions/actionTypes.js
+++ b/src/store/actions/actionTypes.js
@@ -23,3 +23,5 @@ export const PASSWORD_RESET = 'PASSWORD_RESET';
 export const RESET_PASSWORD = 'RESET_PASSWORD';
 export const REDIRECT = 'REDIRECT';
 export const LOGOUT = 'LOGOUT';
+export const SET_TOKEN = 'SET_TOKEN';
+export const USER_VERIFIED = 'USER_VERIFIED';

--- a/src/store/actions/registerActions.js
+++ b/src/store/actions/registerActions.js
@@ -19,7 +19,7 @@ export function registerUser(payload) {
       });
       dispatch({
         type: SHOW_ALERT,
-        payload: { message: response.data.user.message, showAlert: true },
+        payload: { message: response.data.user.message, showAlert: true, colorClass: 'alert-success' },
       });
       dispatch({ type: IS_LOADING, payload: { isLoading: false } });
       dispatch(showErrors({}));

--- a/src/store/reducers/passwordResetReducer.js
+++ b/src/store/reducers/passwordResetReducer.js
@@ -1,15 +1,15 @@
-import { IS_LOADING, REDIRECT } from '../actions/actionTypes';
+import { IS_LOADING, SET_TOKEN } from '../actions/actionTypes';
 
 const initialState = {
   isLoading: false,
-  redirect: false,
+  token: '',
 };
 
 function passwordResetReducer(state = initialState, action) {
   if (action.type === IS_LOADING) {
     return Object.assign({}, state, action.payload);
   }
-  if (action.type === REDIRECT) {
+  if (action.type === SET_TOKEN) {
     return Object.assign({}, state, action.payload);
   }
 

--- a/src/tests/components/ResetPassword.test.js
+++ b/src/tests/components/ResetPassword.test.js
@@ -1,26 +1,13 @@
-import { ConnectedResetPassword } from '../../components/ResetPassword';
-import { shallow, mount } from 'enzyme';
+import ResetPassword from '../../components/ResetPassword';
+import { shallow } from 'enzyme';
 import React from 'react';
-import { mapStateToProps } from '../../components/ResetPassword';
 
 describe('ResetPassword', () => {
   it('renders one Password reset component', () => {
-    const props = {redirect: true}
-    const wrapper = shallow(<ConnectedResetPassword {...props}/>);
-    expect(wrapper).toHaveLength(1);
-  });
-  it('redirects when redirect is true', () => {
-    const props = {redirect: true}
-    const wrapper = shallow(<ConnectedResetPassword {...props}/>);
+    const props = {
+      match: { params: { resetToken: 'fedageds' } }
+    }
+    const wrapper = shallow(<ResetPassword {...props} />);
     expect(wrapper).toHaveLength(1);
   });
 })
-
-describe('MapToProps', () => { 
-  it('should return new state', () => {
-    const newState = mapStateToProps({ resetPasswordState: { redirect: true } });
-    const expected = { redirect: true };
-    expect(newState).toEqual(expected)
-  })
-});
- 

--- a/src/tests/components/passwordResetForm.test.js
+++ b/src/tests/components/passwordResetForm.test.js
@@ -7,7 +7,7 @@ describe('Reset password Reset form', () => {
     PasswordReset: jest.fn(() => {
       Promise.resolve();
     }),
-    ...{ isLoading: false },
+    ...{ isLoading: false, token: 'blahblah'},
   };
 
   let state = {
@@ -44,6 +44,19 @@ describe('Reset password Reset form', () => {
     instance.handleSubmit(event);
     const errorMsg = instance.state.errors.password
     expect(errorMsg).toBe("Password should be at least 8 characters long")
+  });
+
+  it('should show errors when passwords are not equal', () => {
+    const wrapper = mount(<ConnectedPasswordResetForm {...props} />);
+    const instance = wrapper.instance()
+    const event = {
+      preventDefault: jest.fn()
+    };
+
+    instance.setState({password:'fsbdgbhndss', ConfirmPassword: 'vtbgrw'});
+    instance.handleSubmit(event);
+    const errorMsg = instance.state.errors.confirmPassword
+    expect(errorMsg).toBe("Passwords do not match")
   });
 
   it("should call handleChange when input value is changed", () => {


### PR DESCRIPTION
### What does this PR do?
Enable users to verify their emails when they click the verify link in their emails

### Description


 -  [x] Users get a success or error message depending on the validity of the token
 -  [x] This also fixes a bug in the reset password feature

### How has this been tested?
 - [x] Unit tests
 - [x] Integration tests

### How to manually test this:
- Clone the repository `https://github.com/andela/ah-legion-frontend`
- Checkout the branch `ft-verify-user-165530654`
- Run `npm install` to instal the required necessary node modules
- Click a verification link

### PT
[#165530654](https://www.pivotaltracker.com/story/show/165530654)