### PR TITLE
bug(social login): Fix register button texts

### DIFF
--- a/src/components/AuthenticationModal.jsx
+++ b/src/components/AuthenticationModal.jsx
@@ -60,7 +60,7 @@ export class ConnectedAuthenticationModal extends React.Component {
         <Modal.Body className="authentication-modal-body">
           <Container>
             <CurrentComponent />
-            <SocialAccount />
+            { (component === 'register' || component === 'login') && <SocialAccount /> }
           </Container>
         </Modal.Body>
       </Modal>

--- a/src/components/FacebookLogin.jsx
+++ b/src/components/FacebookLogin.jsx
@@ -5,23 +5,23 @@ import PropTypes from 'prop-types';
 import { facebookLoginAction } from '../store/actions/authActions/socialLoginAction';
 
 
-export const FacebookLogin = ({ facebookLogin, isRegister }) => (
+export const FacebookLogin = ({ facebookLogin, component }) => (
   <Button onClick={facebookLogin} variant="outline-secondary" className="btn-auth social-button facebook" block>
     <i className="fab fa-facebook" />
-    {isRegister ? 'Register ' : 'Login '}
+    {component === 'register' ? 'Register ' : 'Login '}
     with Facebook
   </Button>
 );
 
 FacebookLogin.propTypes = {
   facebookLogin: PropTypes.func.isRequired,
-  isRegister: PropTypes.bool.isRequired,
+  component: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = (state) => {
-  const { isRegister } = state.modalState;
+  const { component } = state.modalState;
   return {
-    isRegister,
+    component,
   };
 };
 

--- a/src/components/GoogleLogin.jsx
+++ b/src/components/GoogleLogin.jsx
@@ -4,23 +4,23 @@ import { Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { googleLoginAction } from '../store/actions/authActions/socialLoginAction';
 
-export const GoogleLogin = ({ googleLogin, isRegister }) => (
+export const GoogleLogin = ({ googleLogin, component }) => (
   <Button id="googleBtn" onClick={googleLogin} variant="outline-secondary" className="btn-auth social-button google" block>
     <i className="fab fa-google" />
-    {isRegister ? 'Register ' : 'Login '}
+    {component === 'register' ? 'Register ' : 'Login '}
     with Google
   </Button>
 );
 
 GoogleLogin.propTypes = {
   googleLogin: PropTypes.func.isRequired,
-  isRegister: PropTypes.bool.isRequired,
+  component: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = (state) => {
-  const { isRegister } = state.modalState;
+  const { component } = state.modalState;
   return {
-    isRegister,
+    component,
   };
 };
 

--- a/src/components/TwitterLogin.jsx
+++ b/src/components/TwitterLogin.jsx
@@ -12,25 +12,25 @@ firebase.initializeApp({
   authDomain: REACT_APP_FIREBASE_AUTH_DOMAIN,
 });
 
-export const TwitterLogin = ({ twitterLogin, isRegister }) => (
+export const TwitterLogin = ({ twitterLogin, component }) => (
 
   <Button onClick={twitterLogin} variant="outline-secondary" className="btn-auth social-button twitter" block>
     <i className="fab fa-twitter" />
     {' '}
-    {isRegister ? 'Register ' : 'Login '}
+    {component === 'register' ? 'Register ' : 'Login '}
      with Twitter
   </Button>
 );
 
 TwitterLogin.propTypes = {
   twitterLogin: PropTypes.func.isRequired,
-  isRegister: PropTypes.bool.isRequired,
+  component: PropTypes.string.isRequired,
 };
 
 export const mapStateToProps = (state) => {
-  const { isRegister } = state.modalState;
+  const { component } = state.modalState;
   return {
-    isRegister,
+    component,
   };
 };
 

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -127,7 +127,7 @@ h3 {
   opacity: 1 !important;
   background-color: white;
   max-height: fit-content;
-  min-height: 60%;
+  min-height: 35%;
 }
 
 .modal-dialog {

--- a/src/tests/components/FacebookLogin.test.js
+++ b/src/tests/components/FacebookLogin.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { FacebookLogin , mapDispatchToProps } from '../../components/FacebookLogin';
+import { FacebookLogin , mapDispatchToProps, mapStateToProps } from '../../components/FacebookLogin';
 
 
 describe('GoogleComponent', () => {
@@ -11,7 +11,7 @@ describe('GoogleComponent', () => {
   })
 
   it("Should render with button", () => {
-      const component = shallow(<FacebookLogin isRegister={true} />);
+      const component = shallow(<FacebookLogin component='register' />);
       const button = component.find('button');
       expect(component.length).toBe(1);
   })
@@ -33,5 +33,13 @@ describe('MapDispatchToProps', () => {
   it('should dispatch facebookLogin', () => {
     mapDispatchToProps(dispatch).facebookLogin();
     expect(dispatch).toHaveBeenCalled();
+  });
+});
+
+describe('MapStateToProps', () => { 
+  const state = {modalState: { component: 'register', modalShow: true }}
+  const expected = { component: 'register'}
+  it('returns the modal state', () => {
+    expect(mapStateToProps(state)).toEqual(expected)
   });
 });

--- a/src/tests/components/GoogleLogin.test.js
+++ b/src/tests/components/GoogleLogin.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { GoogleLogin, mapDispatchToProps } from '../../components/GoogleLogin';
-import { Button } from 'react-bootstrap';
+import { GoogleLogin, mapDispatchToProps, mapStateToProps } from '../../components/GoogleLogin';
 
 
 describe('Google Login component', () => {
@@ -11,13 +10,13 @@ describe('Google Login component', () => {
     expect(component.length).toBe(1);
   })
 
-  it("Should render with button", () => {
-    const component = shallow(<GoogleLogin isRegister={true} />);
+  it('Should render with button', () => {
+    const component = shallow(<GoogleLogin component='register' />);
     const button = component.find('button');
     expect(component.length).toBe(1);
   })
 
-  it("Should callfunction when button is clicked", () => {
+  it('Should callfunction when button is clicked', () => {
     const mockFn = jest.fn()
     const props = {
       googleLogin: mockFn
@@ -36,4 +35,11 @@ describe('MapDispatchToProps', () => {
       expect(dispatch).toHaveBeenCalled();
     });
   });
-  
+
+describe('MapStateToProps', () => { 
+    const state = {modalState: { component: 'register', modalShow: true }}
+    const expected = { component: 'register'}
+    it('returns the modal state', () => {
+      expect(mapStateToProps(state)).toEqual(expected)
+    });
+});

--- a/src/tests/components/Header.test.js
+++ b/src/tests/components/Header.test.js
@@ -30,4 +30,10 @@ describe('Header', () => {
     const profileDropdown = component.find('.user-profile-container');
     expect(profileDropdown).toBeDefined();
   });
+
+  it('calls the dispath logout method ', () => {
+    const spy = jest.spyOn(component.instance(), 'dispatchLogout');
+    component.instance().dispatchLogout();
+    expect(spy).toHaveBeenCalled();
+  });
 });

--- a/src/tests/components/TwitterLogin.test.js
+++ b/src/tests/components/TwitterLogin.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
-import { TwitterLogin, mapDispatchToProps } from '../../components/TwitterLogin';
+import { TwitterLogin, mapDispatchToProps, mapStateToProps } from '../../components/TwitterLogin';
 
 
 describe('Twitter Component', () => {
@@ -11,7 +11,7 @@ describe('Twitter Component', () => {
   })
 
   it("Should render with no errors", () => {
-    const component = shallow(<TwitterLogin isRegister={true} />);
+    const component = shallow(<TwitterLogin component='register' />);
     expect(component.find('button')).toBeDefined();
     expect(component.length).toBe(1);
   })
@@ -32,5 +32,13 @@ describe('MapDispatchToProps', () => {
   it('should dispatch twitterLogin', () => {
     mapDispatchToProps(dispatch).twitterLogin();
     expect(dispatch).toHaveBeenCalled();
+  });
+});
+
+describe('MapStateToProps', () => { 
+  const state = {modalState: { component: 'register', modalShow: true }}
+  const expected = { component: 'register'}
+  it('returns the modal state', () => {
+    expect(mapStateToProps(state)).toEqual(expected)
   });
 });


### PR DESCRIPTION
#### Why is this needed?
The social buttons are not correctly prefixed with `Register with ..`  when the modal is in `register` mode.
Social buttons are displayed in when the modal is in `password reset` mode.


#### Step to fix it:
Rename buttons to prefix with `Register with ..` when the modal is in `register` mode.
Stop the social buttons from being displayed when the modal is in `password reset` mode