### PR TITLE
#165630001 Add missing logout link

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -45,6 +45,9 @@ export class Header extends React.Component {
                   <Link to="/articles/drafts" className="nav-dropdown">Drafts</Link>
                   <hr />
                   <Link to="/profile" className="nav-dropdown">Profile</Link>
+                  <hr />
+                  <span className="logout nav-dropdown" onClick={this.dispatchLogout}>Logout</span>
+
 
                 </Popover>
 )}

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -855,6 +855,9 @@ color: #000000;
   color:#333;
   text-decoration: none;
 }
+.logout:hover {
+  cursor: pointer;
+}
 
   /* Styles for React Tags*/
 div.ReactTags__tags {


### PR DESCRIPTION
#### Why is this needed?
The logout link is missing from the navbar.

#### Step to fix it:
Add Logout link to the navbar.